### PR TITLE
Fix test runner events parsing and align with node 20.7.0

### DIFF
--- a/parse-report.js
+++ b/parse-report.js
@@ -5,6 +5,7 @@ import {
   EVENT_TEST_DIAGNOSTIC,
   ERROR_CODE_TEST_FAILURE
 } from './constants.js'
+import { URL, fileURLToPath } from 'node:url'
 
 const durationRegex = /duration_ms\s([\d.]+)/
 
@@ -27,9 +28,21 @@ export default async function parseReport(source) {
     diagnosticMessage = ''
   }
 
-  // Removes file: form the start of the string
-  function parseFilePath(file) {
-    return file.replace(/^file:/, '')
+  function isFileUrl(urlString) {
+    try {
+      const url = new URL(urlString)
+      return url.protocol === 'file:'
+    } catch (error) {
+      return false
+    }
+  }
+
+  function parseFilePath(fileString) {
+    if (isFileUrl(fileString)) {
+      return fileURLToPath(fileString)
+    } else {
+      return fileString
+    }
   }
 
   for await (const event of source) {

--- a/parse-report.js
+++ b/parse-report.js
@@ -27,6 +27,11 @@ export default async function parseReport(source) {
     diagnosticMessage = ''
   }
 
+  // Removes file: form the start of the string
+  function parseFilePath(file) {
+    return file.replace(/^file:/, '')
+  }
+
   for await (const event of source) {
     switch (event.type) {
       case EVENT_TEST_START:
@@ -38,7 +43,7 @@ export default async function parseReport(source) {
 
         testStack.push({
           name,
-          file,
+          file: parseFilePath(file),
           tests: []
         })
 

--- a/test/resources/expected.json
+++ b/test/resources/expected.json
@@ -43,7 +43,7 @@
                   "failure": {
                     "failureType": "testCodeFailure",
                     "cause": {
-                      "generatedMessage": false,
+                      "generatedMessage": true,
                       "code": "ERR_ASSERTION",
                       "actual": 1,
                       "expected": 2,
@@ -58,7 +58,7 @@
               "todo": false,
               "error": {
                 "failureType": "subtestsFailed",
-                "cause": {},
+                "cause": "1 subtest failed",
                 "code": "ERR_TEST_FAILURE"
               }
             }
@@ -68,7 +68,7 @@
           "todo": false,
           "error": {
             "failureType": "subtestsFailed",
-            "cause": {},
+            "cause": "1 subtest failed",
             "code": "ERR_TEST_FAILURE"
           }
         }
@@ -78,7 +78,7 @@
       "todo": false,
       "error": {
         "failureType": "subtestsFailed",
-        "cause": {},
+        "cause": "1 subtest failed",
         "code": "ERR_TEST_FAILURE"
       }
     },
@@ -108,7 +108,7 @@
       "todo": false,
       "error": {
         "failureType": "testTimeoutFailure",
-        "cause": {},
+        "cause": "test timed out after 100ms",
         "code": "ERR_TEST_FAILURE"
       }
     },


### PR DESCRIPTION
This is a list of things changed on node test runner since the latest release:

- File string format is changed now it returns the url scheme too then in our case has _file:_ in front of the path
- generatedMessage must be true in that case because the message is automatically generated, if a custom message is passed as the third parameter of for example strictEquale function the variable will be false
- On subtestFailed failure type now the cause is "<_number_> subtest failed" instead of an empty object
- On testTimeoutFailure failure type now the cause is "test timed out after <_timeout ms_>" instead of an empty object

**Suggested solution:**

- Parse the file url and return it as expected
- Align the expected tests results with node 20.7.0

Closes #82 